### PR TITLE
fix panic if connection refused

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -49,6 +49,7 @@ func (m *MySQL) collect(p *Prometheus) {
 
 	if err != nil {
 		p.DB.Logger.Error(context.Background(), "gorm:prometheus query error: %v", err)
+		return
 	}
 
 	var variableName, variableValue string


### PR DESCRIPTION
Fixed a panic when the connection to the server is lost

Example of panic:
```
ERRO[0060] gorm:prometheus query error: dial tcp 127.0.0.1:11030: connect: connection refused 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x734c40]

goroutine 65 [running]:
database/sql.(*Rows).Next(0x0, 0xc0010933d0)
        /usr/lib/go-1.14/src/database/sql/sql.go:2744 +0x30
gorm.io/plugin/prometheus.(*MySQL).collect(0xc0001ad340, 0xc000305d10)
        /home/user/go/pkg/mod/gorm.io/plugin/prometheus@v0.0.0-20200928065217-b2ba35de3605/mysql.go:55 +0x1d2
gorm.io/plugin/prometheus.(*MySQL).Metrics.func1(0xc0001ad340, 0xc000305d10)
        /home/user/go/pkg/mod/gorm.io/plugin/prometheus@v0.0.0-20200928065217-b2ba35de3605/mysql.go:33 +0x78
created by gorm.io/plugin/prometheus.(*MySQL).Metrics
        /home/user/go/pkg/mod/gorm.io/plugin/prometheus@v0.0.0-20200928065217-b2ba35de3605/mysql.go:31 +0xa8
exit status 2
```