### PR TITLE
fix: typo in postgres comments

### DIFF
--- a/postgres.go
+++ b/postgres.go
@@ -11,7 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// Posgres metrics providers. Metrics is being contructed from Sturct labels:
+// Postgres metrics providers. Metrics are contructed from Struct labels:
 // Type translation:
 //					 int64 - Counter, Gauge
 // 					 time.Time - Gauge


### PR DESCRIPTION

- [x] Do only one thing
- [x] Non breaking API changes
- [] Tested

### What did this pull request do?

Small typo fix on the comments.

### User Case Description

None.
